### PR TITLE
security(protocol): authenticate group senders and reject pre-handshake control signals

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -232,6 +232,14 @@ Examples include:
 These signal payloads are parsed in the live core and tied back to `MSG_ID`,
 session epoch, and delivery telemetry.
 
+**Authentication rule:** `__SIGNAL__` control frames carry protocol state
+changes and are only honored when they arrive on the authenticated secure
+channel (i.e. with `FLAG_ENCRYPTED` set after the handshake). A plaintext
+control signal received *before* the handshake completes is ignored, with the
+sole exception of a graceful `QUIT`. This prevents an on-path attacker from
+injecting unauthenticated signals (spurious ACKs, transfer aborts, BlindBox
+root changes) before the secure channel exists.
+
 ## Acknowledgements and delivery state
 
 The protocol distinguishes local acceptance from peer-confirmed delivery.
@@ -369,9 +377,33 @@ semantics are carried in an **envelope** layer implemented in:
 Offline delivery uses **pairwise** BlindBox roots to each other member (see the
 manuals for user-visible requirements). User-facing behavior: [MANUAL_EN.md](MANUAL_EN.md) / [MANUAL_RU.md](MANUAL_RU.md).
 
+### Group sender authentication
+
+Group messages are fanned out **directly** from sender to each member (there is
+no relaying through a third member). For 1:1-delivered (`recipient` scope, v1)
+group transport — whether carried on the live secure channel or via a pairwise
+BlindBox root — the transport peer is cryptographically authenticated. The
+runtime therefore binds the envelope's self-declared `sender_id` to that
+authenticated peer: if they do not denote the same I2P destination, the message
+is rejected as `INVALID`. This stops a connected group member from injecting a
+message that spoofs another member's identity.
+
+Enforcement lives in `_validate_imported_group_transport(...)` in
+`i2pchat/core/i2p_chat_core.py` and is regression tested in
+`tests/test_protocol_security_audit.py`.
+
+Group-wide BlindBox delivery (`group_blindbox` scope, v2) uses a group-shared
+root, so per-member cryptographic sender attribution is not available in that
+mode; the binding check applies to the authenticated `recipient`-scope path.
+
 ## Security notes
 
 - Post-handshake plaintext traffic is treated as suspicious / downgrade-like.
+- Pre-handshake plaintext `__SIGNAL__` control frames are ignored (except a
+  graceful `QUIT`); control signals are only honored on the authenticated
+  encrypted channel.
+- 1:1-delivered (`recipient` scope) group messages bind their `sender_id` to the
+  authenticated transport peer, preventing member-to-member sender spoofing.
 - Some metadata necessarily remains visible (type, length, preface).
 - Padding reduces but does not eliminate traffic analysis leakage.
 - BlindBox is intentionally narrower than the live protocol and is aimed at

--- a/i2pchat/core/i2p_chat_core.py
+++ b/i2pchat/core/i2p_chat_core.py
@@ -6443,7 +6443,9 @@ class I2PChatCore:
             delivery_reasons=dict(delivery_reasons or {}),
         )
 
-    def _validate_imported_group_transport(self, decoded: Any) -> None:
+    def _validate_imported_group_transport(
+        self, decoded: Any, *, source_peer: Optional[str] = None
+    ) -> None:
         if getattr(decoded, "state", None) is None or getattr(decoded, "envelope", None) is None:
             raise ValueError("Group transport state and envelope are required")
         state = decoded.state
@@ -6481,6 +6483,20 @@ class I2PChatCore:
             raise ValueError("Unsupported group transport content type")
         if not any(same_i2p_destination(sender_id, m) for m in state.members if m):
             raise ValueError("Group transport sender is not a group member")
+        # Sender authentication: for 1:1-delivered ("recipient" scope) group
+        # messages the transport peer is cryptographically authenticated (live
+        # secure channel or pairwise BlindBox root). Bind the self-declared
+        # ``sender_id`` to that authenticated peer so a connected group member
+        # cannot inject a message that spoofs another member's identity.
+        normalized_source_peer = normalize_member_id(source_peer or "")
+        if (
+            delivery_scope == "recipient"
+            and normalized_source_peer
+            and not same_i2p_destination(sender_id, normalized_source_peer)
+        ):
+            raise ValueError(
+                "Group transport sender does not match the authenticated peer"
+            )
         try:
             local_member = self._local_group_member_id()
         except Exception:
@@ -7077,7 +7093,7 @@ class I2PChatCore:
         if decoded is None:
             return None
         try:
-            self._validate_imported_group_transport(decoded)
+            self._validate_imported_group_transport(decoded, source_peer=source_peer)
         except Exception as e:
             detail = _exception_user_message(e)
             self._emit_error(f"Invalid group transport payload: {detail}")
@@ -10328,6 +10344,19 @@ class I2PChatCore:
 
                 elif msg_type == "S":
                     if "__SIGNAL__:" in body:
+                        # Control signals carry protocol state changes (BlindBox
+                        # roots, delivery ACKs, transfer aborts). They must ride
+                        # the authenticated secure channel; only a graceful QUIT
+                        # is honored as a plaintext pre-handshake signal. This
+                        # blocks unauthenticated signal injection before the
+                        # handshake completes.
+                        if not is_encrypted and "QUIT" not in body:
+                            logger.warning(
+                                "Ignoring unauthenticated control signal before "
+                                "secure channel (peer=%s)",
+                                (err_peer or "?")[:24],
+                            )
+                            continue
                         if "GROUP_BLINDBOX_ROOT|" in body:
                             try:
                                 await self._handle_incoming_group_blindbox_root_signal(

--- a/tests/test_protocol_security_audit.py
+++ b/tests/test_protocol_security_audit.py
@@ -1,0 +1,279 @@
+"""
+Protocol security-audit regression tests.
+
+Covers two hardening fixes:
+
+1. Group message sender authentication: for 1:1-delivered ("recipient" scope)
+   group transport, the self-declared ``sender_id`` must match the
+   cryptographically authenticated transport peer (``source_peer``). A connected
+   member must not be able to spoof another member's identity.
+
+2. Pre-handshake control-signal rejection: unauthenticated ``__SIGNAL__`` control
+   frames that arrive in plaintext before the secure channel is established are
+   ignored (except a graceful QUIT).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import types
+import unittest
+
+# Stub out PIL if not installed (mirrors the other protocol tests).
+if "PIL" not in sys.modules:
+    pil_module = types.ModuleType("PIL")
+    pil_image_module = types.ModuleType("PIL.Image")
+    pil_image_module.Image = object  # type: ignore[attr-defined]
+    pil_module.Image = pil_image_module  # type: ignore[attr-defined]
+    sys.modules["PIL"] = pil_module
+    sys.modules["PIL.Image"] = pil_image_module
+
+from i2pchat.core.i2p_chat_core import I2PChatCore
+from i2pchat.groups import (
+    GroupContentType,
+    GroupEnvelope,
+    GroupImportStatus,
+    GroupRecipientDeliveryMetadata,
+    GroupState,
+)
+from i2pchat.groups.wire import encode_group_transport_text
+
+from tests.live_session_helpers import attach_mock_live_session
+
+ALICE_BARE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+BOB_BARE = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+CAROL_BARE = "cccccccccccccccccccccccccccccccccccccccc"
+
+TEST_PEER_B32 = "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk.b32.i2p"
+
+
+class _DummyDest:
+    def __init__(self, base32: str) -> None:
+        self.base32 = base32
+
+
+class _Reader:
+    def __init__(self, payload: bytes) -> None:
+        self._buf = bytearray(payload)
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            partial = bytes(self._buf)
+            self._buf.clear()
+            raise asyncio.IncompleteReadError(partial=partial, expected=n)
+        data = bytes(self._buf[:n])
+        del self._buf[:n]
+        return data
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._buf:
+            return b""
+        if n < 0 or n >= len(self._buf):
+            data = bytes(self._buf)
+            self._buf.clear()
+            return data
+        data = bytes(self._buf[:n])
+        del self._buf[:n]
+        return data
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.buf = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buf.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+def _patch_crypto(core_module):
+    originals = (
+        core_module.crypto.NACL_AVAILABLE,
+        core_module.crypto.encrypt_message,
+        core_module.crypto.decrypt_message,
+        core_module.crypto.compute_mac,
+        core_module.crypto.verify_mac,
+    )
+    core_module.crypto.NACL_AVAILABLE = True
+    core_module.crypto.encrypt_message = lambda _k, p: p  # type: ignore[assignment]
+    core_module.crypto.decrypt_message = lambda _k, c: c  # type: ignore[assignment]
+    core_module.crypto.compute_mac = (
+        lambda _k, _t, _b, seq=None, msg_id=None, flags=None: b"x" * 32
+    )  # type: ignore[assignment]
+    core_module.crypto.verify_mac = (
+        lambda _k, _t, _b, _m, seq=None, msg_id=None, flags=None: True
+    )  # type: ignore[assignment]
+    return originals
+
+
+def _restore_crypto(core_module, originals):
+    (
+        core_module.crypto.NACL_AVAILABLE,
+        core_module.crypto.encrypt_message,
+        core_module.crypto.decrypt_message,
+        core_module.crypto.compute_mac,
+        core_module.crypto.verify_mac,
+    ) = originals
+
+
+def _make_group_wire(sender_id: str, recipient_id: str, *, group_id: str) -> str:
+    state = GroupState(
+        group_id=group_id,
+        epoch=1,
+        members=(ALICE_BARE, BOB_BARE, CAROL_BARE),
+        title="Audit group",
+    )
+    envelope = GroupEnvelope(
+        group_id=group_id,
+        epoch=1,
+        msg_id=f"msg-from-{sender_id[:6]}",
+        sender_id=sender_id,
+        group_seq=1,
+        content_type=GroupContentType.GROUP_TEXT,
+        payload="hello group",
+    )
+    metadata = GroupRecipientDeliveryMetadata(
+        recipient_id=recipient_id,
+        delivery_id=f"{envelope.msg_id}:{recipient_id[:6]}",
+    )
+    return encode_group_transport_text(state, envelope, metadata)
+
+
+class GroupSenderAuthenticationTests(unittest.TestCase):
+    def _make_core(self, tmpdir: str) -> I2PChatCore:
+        core = I2PChatCore(profile="alice")
+        core.get_profile_data_dir = lambda create=True: tmpdir  # type: ignore[method-assign]
+        core.my_dest = _DummyDest(ALICE_BARE)
+        core.create_group(
+            title="Audit group",
+            members=[BOB_BARE, CAROL_BARE],
+            group_id="audit-group-1",
+            epoch=1,
+        )
+        return core
+
+    def test_spoofed_sender_over_authenticated_peer_is_rejected(self) -> None:
+        """Bob's channel claiming a message from Carol must be rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            wire = _make_group_wire(
+                CAROL_BARE, ALICE_BARE, group_id="audit-group-1"
+            )
+            result = core.import_group_transport(wire, source_peer=BOB_BARE)
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.INVALID)
+            self.assertIn("authenticated peer", (result.error or "").lower())
+            # Nothing must be written to group history.
+            self.assertEqual(core.load_group_history("audit-group-1"), [])
+
+    def test_matching_sender_and_authenticated_peer_is_imported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            wire = _make_group_wire(
+                BOB_BARE, ALICE_BARE, group_id="audit-group-1"
+            )
+            result = core.import_group_transport(wire, source_peer=BOB_BARE)
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.IMPORTED)
+            history = core.load_group_history("audit-group-1")
+            self.assertEqual(len(history), 1)
+            self.assertEqual(history[0].sender_id, BOB_BARE)
+
+    def test_sender_authentication_handles_b32_suffix(self) -> None:
+        """A ``.b32.i2p`` source_peer must still match a bare sender id."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            wire = _make_group_wire(
+                BOB_BARE, ALICE_BARE, group_id="audit-group-1"
+            )
+            result = core.import_group_transport(
+                wire, source_peer=f"{BOB_BARE}.b32.i2p"
+            )
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.IMPORTED)
+
+
+class PreHandshakeSignalRejectionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        import i2pchat.core.i2p_chat_core as core_module
+
+        self._core_module = core_module
+        self._originals = _patch_crypto(core_module)
+
+    def tearDown(self):
+        _restore_crypto(self._core_module, self._originals)
+
+    def _make_core(self, **kwargs) -> I2PChatCore:
+        core = I2PChatCore(**kwargs)
+        core._reset_crypto_state = lambda: None  # type: ignore[assignment]
+        return core
+
+    async def test_plaintext_control_signal_before_handshake_is_ignored(self) -> None:
+        core = self._make_core(on_error=lambda _m: None)
+        # Build a plaintext ABORT_FILE control signal (no secure channel yet).
+        payload = core.frame_message_plain("S", "__SIGNAL__:ABORT_FILE")
+        conn = (_Reader(payload), _Writer())
+        k = attach_mock_live_session(
+            core,
+            TEST_PEER_B32,
+            conn,
+            handshake_complete=False,
+            use_encryption=False,
+        )
+        ls = core._live_sessions[k]
+        await core.receive_loop(conn, peer_id=k)
+        # The unauthenticated signal must not mutate transfer state.
+        self.assertFalse(ls._transfer_aborted_by_peer)
+
+    async def test_encrypted_control_signal_after_handshake_is_processed(self) -> None:
+        core = self._make_core(on_error=lambda _m: None)
+        conn = (None, _Writer())
+        k = attach_mock_live_session(
+            core,
+            TEST_PEER_B32,
+            conn,
+            handshake_complete=True,
+            use_encryption=True,
+            shared_key=b"x" * 32,
+        )
+        ls = core._live_sessions[k]
+        # Encrypted signal frame is produced on the same session (seq starts at 0).
+        payload = core.frame_message("S", "__SIGNAL__:ABORT_FILE", peer_id=k)
+        conn = (_Reader(payload), conn[1])
+        ls.conn = conn
+        await core.receive_loop(conn, peer_id=k)
+        self.assertTrue(ls._transfer_aborted_by_peer)
+
+    async def test_plaintext_quit_before_handshake_is_honored(self) -> None:
+        """A graceful QUIT remains valid as a pre-handshake plaintext signal."""
+        systems: list[str] = []
+        core = self._make_core(on_system=systems.append, on_error=lambda _m: None)
+        payload = core.frame_message_plain("S", "__SIGNAL__:QUIT")
+        conn = (_Reader(payload), _Writer())
+        k = attach_mock_live_session(
+            core,
+            TEST_PEER_B32,
+            conn,
+            handshake_complete=False,
+            use_encryption=False,
+        )
+        await core.receive_loop(conn, peer_id=k)
+        self.assertTrue(
+            any("disconnect" in s.lower() for s in systems),
+            systems,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Аудит безопасности протокола

Проведён аудит сетевого протокола I2PChat (vNext framing, handshake, шифрование сессии, anti-replay, групповой транспорт, BlindBox, SAM). Ниже — итог и два внесённых исправления.

### Общая оценка
Ядро протокола устроено крепко: X25519 + Ed25519 handshake с подписью транскрипта (nonce, ephemeral, signing pubkeys, адреса обеих сторон), HKDF-разделение ключей `k_enc`/`k_mac`, encrypt-then-MAC, строгий монотонный anti-replay, TOFU-пиннинг ключей подписи, защита от downgrade (после handshake plaintext-кадры отклоняются). SAM-команды валидируются от инъекций, имена входящих файлов санитизируются.

### Найдено и исправлено

**1. Спуфинг отправителя в групповых сообщениях (Medium/High).**
Групповые сообщения рассылаются напрямую по аутентифицированным парным каналам, но получатель атрибутировал сообщение по самозаявленному `sender_id` из конверта, не сверяя его с аутентифицированным пиром транспорта (`source_peer`). Из-за этого подключённый участник группы мог отправить сообщение с `sender_id`, указывающим на **другого** участника, и получатель сохранял/показывал его как исходящее от того участника.

Исправление: для доставки в режиме `recipient` (1:1) `sender_id` жёстко привязывается к аутентифицированному `source_peer` (сравнение I2P-назначений); несовпадение отклоняется как `INVALID`. Режим `group_blindbox` (v2) использует общий групповой корень, где покомпонентная криптоатрибуция невозможна по устройству — проверка применяется к аутентифицированному пути `recipient`.

**2. Инъекция управляющих сигналов до handshake (Low).**
Управляющие `__SIGNAL__`-кадры (ACK, отмена передачи, синхронизация корней BlindBox) обрабатывались даже когда приходили в открытом виде до установления защищённого канала. Теперь неаутентифицированные plaintext-сигналы до завершения handshake игнорируются; исключение — «вежливый» `QUIT`.

### Тесты
- Новый файл `tests/test_protocol_security_audit.py` (6 тестов): отклонение подделки отправителя, приём при совпадении, нормализация `.b32.i2p`, игнорирование plaintext-сигнала до handshake, обработка зашифрованного сигнала после handshake, honoring `QUIT`.
- Полный прогон: **707 passed, 6 skipped** (`pytest tests/`).

### Затронутые файлы
- `i2pchat/core/i2p_chat_core.py` — привязка `sender_id`↔`source_peer` в `_validate_imported_group_transport`; гейт plaintext-сигналов в receive loop.
- `docs/PROTOCOL.md` — раздел про аутентификацию отправителя групп и правило про сигналы.
- `tests/test_protocol_security_audit.py` — регрессионные тесты.

### Замечания вне scope этого PR (из существующего `docs/AUDIT_EN.md`, не сетевой протокол)
Обновления/установочные пути без криптоподписи манифеста, непиннингованный внешний источник bundled-`i2pd`, опциональный HTTP-эндпоинт BlindBox. Это supply-chain/operational риски, не трогались здесь.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72cd5679-cc5f-4e33-a2ec-88cfeda23f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72cd5679-cc5f-4e33-a2ec-88cfeda23f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

