### PR TITLE
fix(security): authenticate group BlindBox senders

### DIFF
--- a/i2pchat/core/i2p_chat_core.py
+++ b/i2pchat/core/i2p_chat_core.py
@@ -54,6 +54,7 @@ from i2pchat.groups.wire import (
     decode_group_transport_text,
     encode_group_transport_text,
     encode_group_transport_text_v2,
+    group_blindbox_signature_payload,
 )
 from i2pchat.storage.contact_book import (
     load_book,
@@ -6369,7 +6370,20 @@ class I2PChatCore:
                 raise ValueError("Recipient delivery metadata is required for v1 group transport")
             return encode_group_transport_text(state, envelope, metadata)
         if delivery_scope == "group_blindbox":
-            return encode_group_transport_text_v2(state, envelope)
+            if not self.my_signing_seed or not self.my_signing_public:
+                raise ValueError("Local signing identity is required for group BlindBox")
+            signed_payload = group_blindbox_signature_payload(
+                state,
+                envelope,
+                self.my_signing_public,
+            )
+            signature = crypto.sign_data(self.my_signing_seed, signed_payload)
+            return encode_group_transport_text_v2(
+                state,
+                envelope,
+                signer_key=self.my_signing_public,
+                signature=signature,
+            )
         raise ValueError(f"Unsupported group delivery scope: {delivery_scope}")
 
     def _format_group_text_for_ui(
@@ -6517,6 +6531,44 @@ class I2PChatCore:
                 raise ValueError(
                     "Group blindbox transport must not include recipient metadata"
                 )
+            signer_key = getattr(decoded, "signer_key", None)
+            signature = getattr(decoded, "signature", None)
+            if not isinstance(signer_key, bytes) or len(signer_key) != 32:
+                raise ValueError("Group blindbox transport is missing a valid signer key")
+            if not isinstance(signature, bytes) or len(signature) != 64:
+                raise ValueError("Group blindbox transport is missing a valid signature")
+            normalized_sender = self._normalize_peer_addr(sender_id)
+            if local_member and same_i2p_destination(sender_id, local_member):
+                trusted_signer_hex = (
+                    self.my_signing_public.hex()
+                    if isinstance(self.my_signing_public, bytes)
+                    else ""
+                )
+            else:
+                trusted_signer_hex = self.peer_trusted_signing_keys.get(
+                    normalized_sender, ""
+                )
+            if not trusted_signer_hex:
+                raise ValueError(
+                    "Group blindbox sender has no pinned signing key"
+                )
+            try:
+                trusted_signer = bytes.fromhex(trusted_signer_hex)
+            except ValueError as exc:
+                raise ValueError(
+                    "Group blindbox sender has an invalid pinned signing key"
+                ) from exc
+            if not secrets.compare_digest(signer_key, trusted_signer):
+                raise ValueError(
+                    "Group blindbox signer key does not match the pinned sender key"
+                )
+            signed_payload = group_blindbox_signature_payload(
+                state,
+                envelope,
+                signer_key,
+            )
+            if not crypto.verify_signature(signer_key, signed_payload, signature):
+                raise ValueError("Invalid group blindbox sender signature")
             if local_member and not any(
                 same_i2p_destination(local_member, member) for member in state.members if member
             ):

--- a/i2pchat/groups/wire.py
+++ b/i2pchat/groups/wire.py
@@ -18,6 +18,7 @@ from .models import (
 GROUP_TRANSPORT_PREFIX = "__I2PCHAT_GROUP__:"
 GROUP_TRANSPORT_VERSION = 1
 GROUP_TRANSPORT_VERSION_V2 = 2
+GROUP_TRANSPORT_VERSION_V3 = 3
 GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX = "group_blindbox"
 
 
@@ -101,7 +102,7 @@ def group_blindbox_signature_payload(
         raise ValueError("Group blindbox signer key must be 32 bytes")
     payload: dict[str, Any] = {
         "transport": "group",
-        "version": GROUP_TRANSPORT_VERSION_V2,
+        "version": GROUP_TRANSPORT_VERSION_V3,
         "delivery_scope": GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX,
         "group_id": state.group_id,
         "group_title": state.title,
@@ -203,7 +204,7 @@ def _decode_group_transport_v1(payload: dict[str, Any]) -> DecodedGroupTransport
     )
 
 
-def _decode_group_transport_v2(payload: dict[str, Any]) -> DecodedGroupTransportMessage:
+def _decode_group_transport_v3(payload: dict[str, Any]) -> DecodedGroupTransportMessage:
     if (
         str(payload.get("delivery_scope") or "").strip().lower()
         != GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX
@@ -261,7 +262,7 @@ def _decode_group_transport_v2(payload: dict[str, Any]) -> DecodedGroupTransport
         envelope=envelope,
         signer_key=signer_key,
         signature=signature,
-        version=GROUP_TRANSPORT_VERSION_V2,
+        version=GROUP_TRANSPORT_VERSION_V3,
         delivery_scope=GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX,
     )
 
@@ -279,5 +280,7 @@ def decode_group_transport_text(text: str) -> DecodedGroupTransportMessage | Non
     if version == GROUP_TRANSPORT_VERSION:
         return _decode_group_transport_v1(payload)
     if version == GROUP_TRANSPORT_VERSION_V2:
-        return _decode_group_transport_v2(payload)
+        raise ValueError("Unsigned group blindbox transport is no longer accepted")
+    if version == GROUP_TRANSPORT_VERSION_V3:
+        return _decode_group_transport_v3(payload)
     raise ValueError("Unsupported group transport version")

--- a/i2pchat/groups/wire.py
+++ b/i2pchat/groups/wire.py
@@ -57,6 +57,8 @@ class DecodedGroupTransportMessage:
     envelope: GroupEnvelope
     recipient_id: str | None = None
     delivery_id: str | None = None
+    signer_key: bytes | None = None
+    signature: bytes | None = None
     version: int = GROUP_TRANSPORT_VERSION
     delivery_scope: str = "recipient"
 
@@ -90,11 +92,14 @@ def encode_group_transport_text(
     )
 
 
-def encode_group_transport_text_v2(
+def group_blindbox_signature_payload(
     state: GroupState,
     envelope: GroupEnvelope,
-) -> str:
-    payload = {
+    signer_key: bytes,
+) -> bytes:
+    if len(signer_key) != 32:
+        raise ValueError("Group blindbox signer key must be 32 bytes")
+    payload: dict[str, Any] = {
         "transport": "group",
         "version": GROUP_TRANSPORT_VERSION_V2,
         "delivery_scope": GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX,
@@ -108,7 +113,29 @@ def encode_group_transport_text_v2(
         "content_type": str(envelope.content_type),
         "payload": envelope.payload,
         "created_at": _to_iso8601(envelope.created_at),
+        "signer_key": signer_key.hex(),
     }
+    return json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def encode_group_transport_text_v2(
+    state: GroupState,
+    envelope: GroupEnvelope,
+    *,
+    signer_key: bytes,
+    signature: bytes,
+) -> str:
+    if len(signature) != 64:
+        raise ValueError("Group blindbox signature must be 64 bytes")
+    payload = json.loads(
+        group_blindbox_signature_payload(state, envelope, signer_key).decode("utf-8")
+    )
+    payload["signature"] = signature.hex()
     return GROUP_TRANSPORT_PREFIX + json.dumps(
         payload,
         ensure_ascii=True,
@@ -190,6 +217,15 @@ def _decode_group_transport_v2(payload: dict[str, Any]) -> DecodedGroupTransport
     sender_id = normalize_member_id(_required_text_field(payload, "sender_id"))
     if not sender_id:
         raise ValueError("Missing required group transport field: sender_id")
+    try:
+        signer_key = bytes.fromhex(_required_text_field(payload, "signer_key"))
+        signature = bytes.fromhex(_required_text_field(payload, "signature"))
+    except ValueError as exc:
+        raise ValueError("Invalid group blindbox signature encoding") from exc
+    if len(signer_key) != 32:
+        raise ValueError("Group blindbox signer key must be 32 bytes")
+    if len(signature) != 64:
+        raise ValueError("Group blindbox signature must be 64 bytes")
     created_at = _parse_datetime(_required_text_field(payload, "created_at"))
     members_raw = payload.get("members", [])
     if not isinstance(members_raw, list):
@@ -223,6 +259,8 @@ def _decode_group_transport_v2(payload: dict[str, Any]) -> DecodedGroupTransport
     return DecodedGroupTransportMessage(
         state=state,
         envelope=envelope,
+        signer_key=signer_key,
+        signature=signature,
         version=GROUP_TRANSPORT_VERSION_V2,
         delivery_scope=GROUP_TRANSPORT_DELIVERY_SCOPE_GROUP_BLINDBOX,
     )

--- a/i2pchat/router/bundled_i2pd.py
+++ b/i2pchat/router/bundled_i2pd.py
@@ -12,7 +12,7 @@ import time
 from typing import Iterable, Optional
 
 from .runtime import is_tcp_open, pick_free_tcp_port, probe_sam_hello, wait_for_sam_ready
-from .settings import RouterSettings, router_runtime_dir
+from .settings import RouterSettings, require_loopback_host, router_runtime_dir
 
 
 @dataclass
@@ -216,11 +216,12 @@ def _ps_single_quoted(text: str) -> str:
 
 
 def render_i2pd_conf(rt: BundledI2pdRuntime) -> str:
+    sam_host = require_loopback_host(rt.sam_host)
     return f"""daemon = false
 service = false
 
 sam.enabled = true
-sam.address = {rt.sam_host}
+sam.address = {sam_host}
 sam.port = {rt.sam_port}
 
 http.enabled = true

--- a/i2pchat/router/settings.py
+++ b/i2pchat/router/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import ipaddress
 import json
 import os
 from typing import Any
@@ -43,6 +44,12 @@ def bundled_i2pd_allowed() -> bool:
 
 
 def normalize_router_settings(settings: RouterSettings) -> RouterSettings:
+    settings = RouterSettings(
+        **{
+            **asdict(settings),
+            "bundled_sam_host": require_loopback_host(settings.bundled_sam_host),
+        }
+    )
     if bundled_i2pd_allowed():
         return settings
     if settings.backend != "bundled" and not settings.bundled_auto_start:
@@ -73,6 +80,19 @@ def router_runtime_dir() -> str:
 def _coerce_string_setting(value: Any, default: str) -> str:
     text = str(value).strip() if value is not None else ""
     return text or default
+
+
+def require_loopback_host(value: Any, default: str = "127.0.0.1") -> str:
+    """Return a loopback-only host suitable for a bundled router bind."""
+    text = _coerce_string_setting(value, default)
+    if text.lower() == "localhost":
+        return text
+    try:
+        if ipaddress.ip_address(text).is_loopback:
+            return text
+    except ValueError:
+        pass
+    raise ValueError("Bundled SAM host must be a loopback address")
 
 
 def _coerce_int_setting(
@@ -122,7 +142,7 @@ def _coerce_router_settings(raw: dict[str, Any]) -> RouterSettings:
             raw.get("system_sam_port"),
             defaults["system_sam_port"],
         ),
-        bundled_sam_host=_coerce_string_setting(
+        bundled_sam_host=require_loopback_host(
             raw.get("bundled_sam_host"),
             defaults["bundled_sam_host"],
         ),

--- a/tests/test_bundled_i2pd_config.py
+++ b/tests/test_bundled_i2pd_config.py
@@ -41,6 +41,22 @@ class BundledI2pdConfigTests(unittest.TestCase):
         self.assertIn("http.port = 17070", text)
         self.assertIn("logfile = /tmp/router.log", text)
 
+    def test_render_i2pd_conf_rejects_non_loopback_sam_bind(self) -> None:
+        rt = BundledI2pdRuntime(
+            sam_host="0.0.0.0",
+            sam_port=17656,
+            http_proxy_port=14444,
+            socks_proxy_port=14447,
+            control_http_port=17070,
+            data_dir="/tmp/router-data",
+            conf_path="/tmp/i2pd.conf",
+            tunconf_path="/tmp/tunnels.conf",
+            log_path="/tmp/router.log",
+            pidfile_path="/tmp/i2pd.pid",
+        )
+        with self.assertRaisesRegex(ValueError, "loopback"):
+            render_i2pd_conf(rt)
+
     def test_build_launch_args_use_isolated_paths(self) -> None:
         rt = BundledI2pdRuntime(
             sam_host="127.0.0.1",

--- a/tests/test_group_core.py
+++ b/tests/test_group_core.py
@@ -39,6 +39,7 @@ from i2pchat.groups import (
 from i2pchat.groups.wire import (
     encode_group_transport_text,
     encode_group_transport_text_v2,
+    group_blindbox_signature_payload,
 )
 from i2pchat.storage.blindbox_state import BlindBoxState
 from i2pchat.storage.group_store import GroupBlindBoxChannel
@@ -411,9 +412,22 @@ class GroupCoreTests(unittest.IsolatedAsyncioTestCase):
                     content_type=GroupContentType.GROUP_TEXT,
                     payload="offline to both",
                 )
+                alice_signing_seed, alice_signing_public = (
+                    crypto.generate_signing_keypair()
+                )
+                signature = crypto.sign_data(
+                    alice_signing_seed,
+                    group_blindbox_signature_payload(
+                        group_state,
+                        incoming_envelope,
+                        alice_signing_public,
+                    ),
+                )
                 incoming_wire = encode_group_transport_text_v2(
                     group_state,
                     incoming_envelope,
+                    signer_key=alice_signing_public,
+                    signature=signature,
                 )
                 frame = seed_core._codec.encode(
                     "U",
@@ -448,6 +462,9 @@ class GroupCoreTests(unittest.IsolatedAsyncioTestCase):
                     core.my_dest = _DummyDest(local_member)
                     core.my_signing_seed, core.my_signing_public = (
                         crypto.generate_signing_keypair()
+                    )
+                    core.peer_trusted_signing_keys[ALICE_BARE] = (
+                        alice_signing_public.hex()
                     )
                     core.save_group_state(group_state)
                     core._save_group_blindbox_channel(

--- a/tests/test_protocol_security_audit.py
+++ b/tests/test_protocol_security_audit.py
@@ -30,6 +30,7 @@ if "PIL" not in sys.modules:
     sys.modules["PIL"] = pil_module
     sys.modules["PIL.Image"] = pil_image_module
 
+from i2pchat import crypto
 from i2pchat.core.i2p_chat_core import I2PChatCore
 from i2pchat.groups import (
     GroupContentType,
@@ -38,7 +39,11 @@ from i2pchat.groups import (
     GroupRecipientDeliveryMetadata,
     GroupState,
 )
-from i2pchat.groups.wire import encode_group_transport_text
+from i2pchat.groups.wire import (
+    encode_group_transport_text,
+    encode_group_transport_text_v2,
+    group_blindbox_signature_payload,
+)
 
 from tests.live_session_helpers import attach_mock_live_session
 
@@ -150,6 +155,40 @@ def _make_group_wire(sender_id: str, recipient_id: str, *, group_id: str) -> str
     return encode_group_transport_text(state, envelope, metadata)
 
 
+def _make_signed_group_blindbox_wire(
+    sender_id: str,
+    signing_seed: bytes,
+    signing_public: bytes,
+    *,
+    group_id: str,
+) -> str:
+    state = GroupState(
+        group_id=group_id,
+        epoch=1,
+        members=(ALICE_BARE, BOB_BARE, CAROL_BARE),
+        title="Audit group",
+    )
+    envelope = GroupEnvelope(
+        group_id=group_id,
+        epoch=1,
+        msg_id=f"offline-from-{sender_id[:6]}",
+        sender_id=sender_id,
+        group_seq=1,
+        content_type=GroupContentType.GROUP_TEXT,
+        payload="offline hello",
+    )
+    signature = crypto.sign_data(
+        signing_seed,
+        group_blindbox_signature_payload(state, envelope, signing_public),
+    )
+    return encode_group_transport_text_v2(
+        state,
+        envelope,
+        signer_key=signing_public,
+        signature=signature,
+    )
+
+
 class GroupSenderAuthenticationTests(unittest.TestCase):
     def _make_core(self, tmpdir: str) -> I2PChatCore:
         core = I2PChatCore(profile="alice")
@@ -200,6 +239,39 @@ class GroupSenderAuthenticationTests(unittest.TestCase):
             result = core.import_group_transport(
                 wire, source_peer=f"{BOB_BARE}.b32.i2p"
             )
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.IMPORTED)
+
+    def test_group_blindbox_rejects_member_spoofing_another_sender(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            bob_seed, bob_public = crypto.generate_signing_keypair()
+            _carol_seed, carol_public = crypto.generate_signing_keypair()
+            core.peer_trusted_signing_keys[CAROL_BARE] = carol_public.hex()
+            wire = _make_signed_group_blindbox_wire(
+                CAROL_BARE,
+                bob_seed,
+                bob_public,
+                group_id="audit-group-1",
+            )
+            result = core.import_group_transport(wire)
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.INVALID)
+            self.assertIn("pinned sender key", (result.error or "").lower())
+            self.assertEqual(core.load_group_history("audit-group-1"), [])
+
+    def test_group_blindbox_accepts_signature_from_pinned_sender(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            bob_seed, bob_public = crypto.generate_signing_keypair()
+            core.peer_trusted_signing_keys[BOB_BARE] = bob_public.hex()
+            wire = _make_signed_group_blindbox_wire(
+                BOB_BARE,
+                bob_seed,
+                bob_public,
+                group_id="audit-group-1",
+            )
+            result = core.import_group_transport(wire)
             assert result is not None
             self.assertEqual(result.status, GroupImportStatus.IMPORTED)
 

--- a/tests/test_protocol_security_audit.py
+++ b/tests/test_protocol_security_audit.py
@@ -275,6 +275,22 @@ class GroupSenderAuthenticationTests(unittest.TestCase):
             assert result is not None
             self.assertEqual(result.status, GroupImportStatus.IMPORTED)
 
+    def test_group_blindbox_rejects_legacy_unsigned_protocol_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            core = self._make_core(tmpdir)
+            bob_seed, bob_public = crypto.generate_signing_keypair()
+            core.peer_trusted_signing_keys[BOB_BARE] = bob_public.hex()
+            wire = _make_signed_group_blindbox_wire(
+                BOB_BARE,
+                bob_seed,
+                bob_public,
+                group_id="audit-group-1",
+            ).replace('"version":3', '"version":2')
+            result = core.import_group_transport(wire)
+            assert result is not None
+            self.assertEqual(result.status, GroupImportStatus.INVALID)
+            self.assertIn("unsigned", (result.error or "").lower())
+
 
 class PreHandshakeSignalRejectionTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):

--- a/tests/test_router_settings.py
+++ b/tests/test_router_settings.py
@@ -99,6 +99,32 @@ class RouterSettingsTests(unittest.TestCase):
                 self.assertEqual(loaded.bundled_control_http_port, 20004)
                 self.assertTrue(loaded.bundled_auto_start)
 
+    def test_save_rejects_non_loopback_bundled_sam_host(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch("i2pchat.router.settings.get_profiles_dir", return_value=td):
+                with self.assertRaisesRegex(ValueError, "loopback"):
+                    save_router_settings(
+                        RouterSettings(
+                            backend="bundled",
+                            bundled_sam_host="0.0.0.0",
+                        )
+                    )
+
+    def test_load_invalid_bundled_sam_host_falls_back_to_safe_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch("i2pchat.router.settings.get_profiles_dir", return_value=td):
+                with open(router_settings_path(), "w", encoding="utf-8") as f:
+                    json.dump(
+                        {
+                            "backend": "bundled",
+                            "bundled_sam_host": "127.0.0.1\nhttp.enabled = false",
+                        },
+                        f,
+                    )
+                loaded = load_router_settings()
+                self.assertEqual(loaded.backend, "system")
+                self.assertEqual(loaded.bundled_sam_host, "127.0.0.1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- introduce signed group-wide BlindBox protocol v3 using the sender's Ed25519 identity
- require signatures to match the sender's pinned signing key before importing messages
- reject legacy unsigned v2 messages to prevent downgrade and old-client acceptance
- restrict bundled i2pd SAM binding to loopback and reject configuration injection
- add regression coverage for sender spoofing, downgrade rejection, valid signed delivery, and unsafe SAM hosts

## Security impact
Prevents a group member with the shared legacy BlindBox secret from forging messages as another member. The version bump also makes older clients reject the new envelope instead of silently accepting it without signature validation. Bundled SAM can no longer be exposed on non-loopback interfaces.

## Testing
- full suite: 744 passed, 5 skipped, 64 subtests passed
- pip-audit runtime and build lock exports: no known vulnerabilities
- gitleaks: 678 commits scanned, no leaks found
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5757-5ab1-7409-9c60-2486ddf439b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5757-5ab1-7409-9c60-2486ddf439b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

